### PR TITLE
update for opal 0.10.2

### DIFF
--- a/lib/patches/react.rb
+++ b/lib/patches/react.rb
@@ -1,0 +1,9 @@
+module React
+  class RenderingContext
+    def self.remove_nodes_from_args(args)
+      args[0].each do |key, value|
+        value.as_node if `value['$is_a?']` && value.is_a?(Element)
+      end if args[0] && args[0].is_a?(Hash)
+    end
+  end
+end

--- a/lib/react/router/dsl/route/wrappers.rb
+++ b/lib/react/router/dsl/route/wrappers.rb
@@ -7,7 +7,8 @@ module React
             children, index, promise =
               React::Router::DSL.evaluate_children(TransitionContext.new(location: location),
                                                    &@get_children)
-            if promise.class < Promise
+            if promise.class < Promise || promise.is_a?(Promise)
+
               promise.then do |children|
                 callBack.call(nil.to_n, React::Router::DSL.children_to_n(children))
               end.fail { |err_object| callBack.call(err_object, nil.to_n) }
@@ -16,7 +17,6 @@ module React
             end
           end
         end
-
         def get_components_wrapper
           lambda do |nextState, callBack|
             result_hash = {}
@@ -24,7 +24,7 @@ module React
             @components.each do |name, proc_or_comp|
               if proc_or_comp.respond_to? :call
                 comp = proc.call(TransitionContext.new(next_state: nextState))
-                if comp.class < Promise
+                if comp.class < Promise || comp.is_a?(Promise)
                   promises << comp
                   comp.then do |component|
                     result_hash[name] = React::API.create_native_react_class(component)
@@ -43,7 +43,7 @@ module React
         def get_component_wrapper
           lambda do |nextState, callBack|
             comp = @component.call(TransitionContext.new(next_state: nextState))
-            if comp.class < Promise
+            if comp.class < Promise || comp.is_a?(Promise)
               comp.then do |component|
                 component = React::API.create_native_react_class(component)
                 `callBack(null, component)`
@@ -58,8 +58,9 @@ module React
         def on_enter_wrapper
           lambda do |nextState, replace, callBack|
             comp =
-              @opts[:on_enter].call(TransitionContext.new(next_state: nextState, replace: replace))
-            if comp.class < Promise
+              @opts[:on_enter].call(TransitionContext.new(next_state: nextState,
+                                                          replace: replace))
+            if comp.class < Promise || comp.is_a?(Promise)
               comp.then { `callBack()` }
             else
               `callBack()`
@@ -72,7 +73,7 @@ module React
             comp = @opts[:on_change].call(TransitionContext.new(prev_state: prevState,
                                                                 next_state: nextState,
                                                                 replace: replace))
-            if comp.class < Promise
+            if comp.class < Promise || comp.is_a?(Promise)
               comp.then { `callBack()` }
             else
               `callBack()`
@@ -89,7 +90,7 @@ module React
         def get_index_route_wrapper
           lambda do |location, callBack|
             comp = @opts[:index].call(TransitionContext.new(location: location))
-            if comp.class < Promise
+            if comp.class < Promise || comp.is_a?(Promise)
               comp.then { |component| `callBack(null, {component: #{component}})` }
                   .fail { |err_object| `callBack(#{err_object}, null)` }
             else

--- a/lib/reactrb-router.rb
+++ b/lib/reactrb-router.rb
@@ -8,6 +8,7 @@ if RUBY_ENGINE == 'opal'
   require 'react/router/dsl/route'
   require 'react/router/dsl/index'
   require 'react/router/dsl/transition_context'
+  require 'patches/react'
 else
   require 'opal'
   require 'reactrb'

--- a/reactrb-router.gemspec
+++ b/reactrb-router.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   # For Test Rails App
   s.add_development_dependency 'rails', '4.2.4'
   s.add_development_dependency 'react-rails', '1.3.1'
-  s.add_development_dependency 'opal-rails', '0.8.1'
+  s.add_development_dependency 'opal-rails', '0.9.0'
 
   if RUBY_PLATFORM == 'java'
     s.add_development_dependency 'jdbc-sqlite3'
@@ -51,7 +51,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'rspec-collection_matchers'
     s.add_development_dependency 'database_cleaner'
     s.add_development_dependency 'capybara'
-    s.add_development_dependency 'selenium-webdriver'
+    s.add_development_dependency 'selenium-webdriver', '~> 2.0'
     s.add_development_dependency 'poltergeist'
     s.add_development_dependency 'spring-commands-rspec'
     s.add_development_dependency 'chromedriver-helper'

--- a/spec/reactrb_router/router_hooks_spec.rb
+++ b/spec/reactrb_router/router_hooks_spec.rb
@@ -145,7 +145,7 @@ describe 'Router class', js: true do
     run_on_client { TestRouter.promise.resolve('BOGUS') }
     page.should have_content('Rendering App: No Children')
     event_history_for('Error').flatten.should eq(['Rejected: This is never going to work',
-                                                  'uninitialized constant Object::BOGUS'])
+                                                  'uninitialized constant BOGUS'])
   end
 
   it 'can have a #on_update hook' do


### PR DESCRIPTION
#5

added React::RenderingContext::remove_nodes_from_args(args)
changed wrapper promise logic
  from: "promise.class < Promise"
  to: "promise.class < Promise || promise.is_a?(Promise)"

changed router_hooks_spec.rb - on_error - event_history expected value
  to account for change in Opals error message
